### PR TITLE
Fixes media URLs with query strings

### DIFF
--- a/shp-rssimage.php
+++ b/shp-rssimage.php
@@ -51,7 +51,7 @@ function shp_rssimage_extend() {
 	$out = sprintf(
 		'%1$s<media:content url="%2$s" type="%3$s" medium="image" width="%4$s" height="%5$s" />',
 		PHP_EOL,
-		$image_url,
+		str_replace('&', '&#038;', $image_url),
 		$image_mime_type,
 		$image_dimensions['width'],
 		$image_dimensions['height']


### PR DESCRIPTION
Media URLs that include query string parameters (_for example:_ `cdn.com/image.jpg?format=webp&lossy=true`) makes the generated XML invalid. This PR attempts to fix that.